### PR TITLE
🐛 fix : 포탈 로그인 api ResponseEntity 두 번 감싸는 오류 해결

### DIFF
--- a/src/main/java/com/example/ingle/domain/member/controller/AuthController.java
+++ b/src/main/java/com/example/ingle/domain/member/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController implements AuthApiSpecification{
     // 포털 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
-        return ResponseEntity.status(HttpStatus.OK).body(authService.login(loginRequestDto));
+        return authService.login(loginRequestDto);
     }
 
     // 토큰 재발급


### PR DESCRIPTION
## 📎 관련 이슈

- closed #1 

## 📄 설명

- 포탈 로그인 api ResponseEntity 두 번 감싸는 오류 해결

## 🤔 추후 작업 사항

- ❌