### PR TITLE
🔧 chore : 회원 프로필 이미지 수정 시 파일 명만 요청받도록 수정 - #78

### DIFF
--- a/src/main/java/com/example/ingle/domain/building/domain/Building.java
+++ b/src/main/java/com/example/ingle/domain/building/domain/Building.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Entity
+@Table(name = "building")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Building extends BaseEntity {

--- a/src/main/java/com/example/ingle/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/example/ingle/domain/member/controller/MemberApiSpecification.java
@@ -4,6 +4,7 @@ import com.example.ingle.domain.image.dto.response.ImageResponse;
 import com.example.ingle.domain.member.dto.req.FeedbackRequest;
 import com.example.ingle.domain.member.dto.req.MemberInfoRequest;
 import com.example.ingle.domain.member.dto.res.FeedbackResponse;
+import com.example.ingle.domain.member.dto.res.MemberProfileImageResponse;
 import com.example.ingle.domain.member.dto.res.MyPageResponse;
 import com.example.ingle.global.exception.ErrorResponseEntity;
 import com.example.ingle.domain.member.domain.MemberDetail;
@@ -17,6 +18,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -82,7 +84,8 @@ public interface MemberApiSpecification {
 
     @Operation(
             summary = "프로필 이미지 수정",
-            description = "로그인 된 사용자의 프로필 이미지를 수정합니다.",
+            description = "로그인 된 사용자의 프로필 이미지를 수정합니다. <br><br>" +
+                    "이미지의 이름을 보내주세요. ex) Transit, Dormitory, Library, Club ...",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -105,8 +108,8 @@ public interface MemberApiSpecification {
                     )
             }
     )
-    ResponseEntity<ImageResponse> updateProfileImage(@AuthenticationPrincipal MemberDetail memberDetail,
-                                                     @RequestPart("image") MultipartFile image);
+    ResponseEntity<MemberProfileImageResponse> updateProfileImage(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                                         @RequestParam String imageName);
 
     @Operation(
             summary = "피드백 전송",

--- a/src/main/java/com/example/ingle/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/ingle/domain/member/controller/MemberController.java
@@ -1,20 +1,18 @@
 package com.example.ingle.domain.member.controller;
 
-import com.example.ingle.domain.image.dto.response.ImageResponse;
 import com.example.ingle.domain.member.domain.MemberDetail;
 import com.example.ingle.domain.member.dto.req.FeedbackRequest;
 import com.example.ingle.domain.member.dto.req.MemberInfoRequest;
 import com.example.ingle.domain.member.dto.res.FeedbackResponse;
+import com.example.ingle.domain.member.dto.res.MemberProfileImageResponse;
 import com.example.ingle.domain.member.dto.res.MyPageResponse;
 import com.example.ingle.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,10 +35,10 @@ public class MemberController implements MemberApiSpecification{
     }
 
     // 프로필 사진 수정
-    @PutMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ImageResponse> updateProfileImage(@AuthenticationPrincipal MemberDetail memberDetail,
-                                                            @RequestPart("image") MultipartFile image) {
-        return ResponseEntity.status(HttpStatus.OK).body(memberService.updateProfileImage(memberDetail, image));
+    @PutMapping("/profile-image")
+    public ResponseEntity<MemberProfileImageResponse> updateProfileImage(@AuthenticationPrincipal MemberDetail memberDetail,
+                                                                         @RequestParam String imageName) {
+        return ResponseEntity.status(HttpStatus.OK).body(memberService.updateProfileImage(memberDetail, imageName));
     }
 
     // 피드백 전송

--- a/src/main/java/com/example/ingle/domain/member/domain/Member.java
+++ b/src/main/java/com/example/ingle/domain/member/domain/Member.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {

--- a/src/main/java/com/example/ingle/domain/member/dto/res/MemberProfileImageResponse.java
+++ b/src/main/java/com/example/ingle/domain/member/dto/res/MemberProfileImageResponse.java
@@ -1,0 +1,8 @@
+package com.example.ingle.domain.member.dto.res;
+
+public record MemberProfileImageResponse(
+
+        String imageUrl
+
+) {
+}

--- a/src/main/java/com/example/ingle/domain/stamp/repository/StampRepository.java
+++ b/src/main/java/com/example/ingle/domain/stamp/repository/StampRepository.java
@@ -1,7 +1,9 @@
 package com.example.ingle.domain.stamp.repository;
 
+import com.example.ingle.domain.member.dto.res.MemberProfileImageResponse;
 import com.example.ingle.domain.stamp.entity.Stamp;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,11 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
     Optional<Stamp> findByTutorialId(Long tutorialId);
 
     List<Stamp> findAllByOrderById();
+
+    @Query("""
+    SELECT new com.example.ingle.domain.member.dto.res.MemberProfileImageResponse(s.imageUrl)
+    FROM Stamp s
+    WHERE s.name = :name
+""")
+    Optional<MemberProfileImageResponse> findByName(String name);
 }


### PR DESCRIPTION
## 📎 관련 이슈

- closed #78 

## 📄 설명
> 현재 프로필 이미지 수정 시 항상 이미지를 받음
- 이미지 수정 시 파일 명만 전송 받고 해당 파일을 find하여 수정 및 반환하도록 수정

## 🤔 추후 작업 사항

- ❌