### PR TITLE
🐜 fix: 프로필 이미지 저장 엔티티 추가 및 업로드, 조회 로직 추가

### DIFF
--- a/src/main/java/com/example/ingle/domain/building/dto/req/ImageUploadRequest.java
+++ b/src/main/java/com/example/ingle/domain/building/dto/req/ImageUploadRequest.java
@@ -1,0 +1,18 @@
+package com.example.ingle.domain.building.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이미지 업로드 요청")
+public record ImageUploadRequest(
+
+        @Schema(description = "파일명", example = "Crab")
+        @NotBlank(message = "파일명이 비어있습니다.")
+        String name,
+
+        @Schema(description = "카테고리", example = "profile-image")
+        @NotBlank(message = "카테고리가 비어있습니다.")
+        String category
+
+) {
+}

--- a/src/main/java/com/example/ingle/domain/image/controller/ImageApiSpecification.java
+++ b/src/main/java/com/example/ingle/domain/image/controller/ImageApiSpecification.java
@@ -1,0 +1,48 @@
+package com.example.ingle.domain.image.controller;
+
+import com.example.ingle.domain.building.dto.req.ImageUploadRequest;
+import com.example.ingle.domain.image.dto.response.ImageResponse;
+import com.example.ingle.domain.member.dto.res.LoginSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Image", description = "이미지 관련 API")
+public interface ImageApiSpecification {
+
+    @Operation(summary = "이미지 조회",
+            description = "이미지 파일 명을 기반으로 이미지를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "이미지 조회 성공",
+                            content = @Content(
+                                    mediaType = "image/png"
+                            )
+                    )
+            }
+    )
+    ResponseEntity<byte[]> getImage(@PathVariable String filename);
+
+
+    @Operation(summary = "이미지 업로드",
+            description = "이미지를 업로드합니다. <br><br>" + "파일명과 카테고리를 보내주세요.",
+            responses = {
+                    @ApiResponse(responseCode = "201",
+                            description = "이미지 업로드 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ImageResponse.class)
+                            )
+                    )
+            }
+    )
+    ResponseEntity<ImageResponse> uploadImage(@RequestBody ImageUploadRequest request,
+                                           @RequestPart("image") MultipartFile image);
+}

--- a/src/main/java/com/example/ingle/domain/image/controller/ImageController.java
+++ b/src/main/java/com/example/ingle/domain/image/controller/ImageController.java
@@ -1,27 +1,28 @@
 package com.example.ingle.domain.image.controller;
 
+import com.example.ingle.domain.building.dto.req.ImageUploadRequest;
+import com.example.ingle.domain.image.dto.response.ImageResponse;
 import com.example.ingle.domain.image.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/images")
-@Tag(name = "Image", description = "이미지 관련 API")
-public class ImageController {
+public class ImageController implements ImageApiSpecification{
 
     private final ImageService imageService;
 
     // 이미지 조회
-    @Operation(summary = "이미지 조회", description = "이미지 파일 명을 기반으로 이미지를 조회합니다.")
     @GetMapping("/{filename}")
     public ResponseEntity<byte[]> getImage(@PathVariable String filename) {
         return ResponseEntity.status(HttpStatus.OK)
@@ -29,5 +30,12 @@ public class ImageController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"")
                 .header(HttpHeaders.CACHE_CONTROL, "max-age=3600")
                 .body(imageService.getImage(filename));
+    }
+
+    // 이미지 업로드
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImageResponse> uploadImage(@RequestBody ImageUploadRequest request,
+                                                  @RequestPart("image") MultipartFile image) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(imageService.uploadImage(image, request.name(), request.category()));
     }
 }

--- a/src/main/java/com/example/ingle/domain/image/domain/Image.java
+++ b/src/main/java/com/example/ingle/domain/image/domain/Image.java
@@ -1,0 +1,36 @@
+package com.example.ingle.domain.image.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Column(nullable = false, length = 100)
+    private String category;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    private Image (String name, String category, String imageUrl) {
+        this.name = name;
+        this.category = category;
+        this.imageUrl = imageUrl;
+    }
+
+    public static Image create(String name, String category, String imageUrl) {
+        return new Image(name, category, imageUrl);
+    }
+}

--- a/src/main/java/com/example/ingle/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/example/ingle/domain/image/repository/ImageRepository.java
@@ -1,0 +1,18 @@
+package com.example.ingle.domain.image.repository;
+
+import com.example.ingle.domain.image.domain.Image;
+import com.example.ingle.domain.member.dto.res.MemberProfileImageResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    @Query("""
+    SELECT new com.example.ingle.domain.member.dto.res.MemberProfileImageResponse(i.imageUrl)
+    FROM Image i
+    WHERE i.name = :imageName
+""")
+    Optional<MemberProfileImageResponse> findByName(String imageName);
+}

--- a/src/main/java/com/example/ingle/domain/image/service/ImageService.java
+++ b/src/main/java/com/example/ingle/domain/image/service/ImageService.java
@@ -1,12 +1,15 @@
 package com.example.ingle.domain.image.service;
 
+import com.example.ingle.domain.image.domain.Image;
 import com.example.ingle.domain.image.dto.response.ImageResponse;
+import com.example.ingle.domain.image.repository.ImageRepository;
 import com.example.ingle.global.exception.CustomException;
 import com.example.ingle.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -20,6 +23,8 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 public class ImageService {
+
+    private final ImageRepository imageRepository;
 
     @Value("${file.upload-dir}")
     private String fileDirectory;
@@ -51,6 +56,16 @@ public class ImageService {
             log.error("이미지 읽기 실패: {}", e.getMessage());
             throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
         }
+    }
+
+    @Transactional
+    public ImageResponse uploadImage(MultipartFile file, String name, String category) {
+        ImageResponse imageResponse = saveImage(file);
+
+        Image image = Image.create(name, category, imageResponse.url());
+        imageRepository.save(image);
+        // 추가로 이미지 메타데이터(예: name, category)를 DB에 저장하는 로직이 필요할 수 있습니다.
+        return imageResponse;
     }
 
     public String getContentType(String filename) {

--- a/src/main/java/com/example/ingle/domain/member/controller/MemberApiSpecification.java
+++ b/src/main/java/com/example/ingle/domain/member/controller/MemberApiSpecification.java
@@ -85,7 +85,7 @@ public interface MemberApiSpecification {
     @Operation(
             summary = "프로필 이미지 수정",
             description = "로그인 된 사용자의 프로필 이미지를 수정합니다. <br><br>" +
-                    "이미지의 이름을 보내주세요. ex) Transit, Dormitory, Library, Club ...",
+                    "이미지의 이름을 보내주세요. (Seal, Sloth, Jellyfish, Elephant, Fox, Crab, Bee, Snail, Axolotl)",
             responses = {
                     @ApiResponse(
                             responseCode = "200",

--- a/src/main/java/com/example/ingle/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/ingle/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.example.ingle.domain.member.service;
 
 import com.example.ingle.domain.image.dto.response.ImageResponse;
+import com.example.ingle.domain.image.repository.ImageRepository;
 import com.example.ingle.domain.image.service.ImageService;
 import com.example.ingle.domain.member.domain.Feedback;
 import com.example.ingle.domain.member.domain.Member;
@@ -27,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final StampRepository stampRepository;
+    private final ImageRepository imageRepository;
 
     @Transactional(readOnly = true)
     public MyPageResponse getMyPage(MemberDetail memberDetail) {
@@ -49,7 +50,11 @@ public class MemberService {
     public MemberProfileImageResponse updateProfileImage(MemberDetail memberDetail, String imageName) {
         Member member = getMemberByStudentId(memberDetail.getUsername());
 
-        return changeProfileImage(member, imageName);
+        MemberProfileImageResponse memberProfileImageResponse = getProfileImage(imageName);
+
+        member.updateProfileImage(memberProfileImageResponse.imageUrl());
+
+        return memberProfileImageResponse;
     }
 
     @Transactional
@@ -68,14 +73,11 @@ public class MemberService {
                 });
     }
 
-    private MemberProfileImageResponse changeProfileImage(Member member, String imageName) {
-        MemberProfileImageResponse memberProfileImageResponse = stampRepository.findByName(imageName)
+    private MemberProfileImageResponse getProfileImage(String imageName) {
+        return imageRepository.findByName(imageName)
                 .orElseThrow(() -> {
                     log.warn("[프로필 사진 변경 실패] 이미지 없음: imageName={}", imageName);
                     return new CustomException(ErrorCode.IMAGE_NOT_FOUND);
                 });
-        member.updateProfileImage(memberProfileImageResponse.imageUrl());
-
-        return memberProfileImageResponse;
     }
 }

--- a/src/main/java/com/example/ingle/domain/stamp/repository/StampRepository.java
+++ b/src/main/java/com/example/ingle/domain/stamp/repository/StampRepository.java
@@ -13,11 +13,4 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
     Optional<Stamp> findByTutorialId(Long tutorialId);
 
     List<Stamp> findAllByOrderById();
-
-    @Query("""
-    SELECT new com.example.ingle.domain.member.dto.res.MemberProfileImageResponse(s.imageUrl)
-    FROM Stamp s
-    WHERE s.name = :name
-""")
-    Optional<MemberProfileImageResponse> findByName(String name);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,8 @@ spring:
           auto: update
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: false
+        use_sql_comments: false
+        type: false
         jdbc:
           time_zone: Asia/Seoul
 


### PR DESCRIPTION
## 📎 관련 이슈

- closed #78 

## 📄 설명
> 프로필 이미지는 스탬프 이미지와 다른 것을 확인
- 프로필 이미지들을 담을 Image 엔티티, 레포지토리 생성
- 이미지 업로드 api 추가
- 프로필 이미지 변경 로직 수정

## 🤔 추후 작업 사항

- ❌